### PR TITLE
Add default value when trying to lookup organization status field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add default value when trying to look up the organization namespace from the organization status field, as this may be empty when the organization was just created.
+
 ## [0.2.0] - 2023-03-07
 
 ### Added

--- a/helm/kyverno-policies-ux/templates/organization-deletion-when-has-clusters.yaml
+++ b/helm/kyverno-policies-ux/templates/organization-deletion-when-has-clusters.yaml
@@ -22,13 +22,14 @@ spec:
     context:
       - name: clusterCount
         apiCall:
-          urlPath: "/apis/cluster.x-k8s.io/v1beta1/namespaces/{{ `{{` }}request.oldObject.status.namespace{{ `}}` }}/clusters"
+          urlPath: "/apis/cluster.x-k8s.io/v1beta1/namespaces/{{ `{{` }}request.oldObject.status.namespace || ''{{ `}}` }}/clusters"
           jmesPath: "items | length(@)"
     preconditions:
-      any:
-      - key: "{{ `{{` }}clusterCount{{ `}}` }}"
-        operator: GreaterThan
-        value: "0"
+      all:
+      - key: "{{ `{{` }} request.operation {{ `}}` }}"
+        operator: In
+        value:
+        - DELETE
     validate:
       message: "There are currently {{ `{{` }}clusterCount{{ `}}` }} clusters that belong to this organization. If you want to remove the organization, first remove the clusters."
       deny:
@@ -37,3 +38,6 @@ spec:
           operator: In
           value:
           - DELETE
+        - key: "{{ `{{` }}clusterCount{{ `}}` }}"
+          operator: GreaterThan
+          value: "0"

--- a/policies/ux/organization-deletion-when-has-clusters.yaml
+++ b/policies/ux/organization-deletion-when-has-clusters.yaml
@@ -21,13 +21,14 @@ spec:
     context:
       - name: clusterCount
         apiCall:
-          urlPath: "/apis/cluster.x-k8s.io/v1beta1/namespaces/{{request.oldObject.status.namespace}}/clusters"
+          urlPath: "/apis/cluster.x-k8s.io/v1beta1/namespaces/{{request.oldObject.status.namespace || ''}}/clusters"
           jmesPath: "items | length(@)"
     preconditions:
-      any:
-      - key: "{{clusterCount}}"
-        operator: GreaterThan
-        value: "0"
+      all:
+      - key: "{{ request.operation }}"
+        operator: In
+        value:
+        - DELETE
     validate:
       message: "There are currently {{clusterCount}} clusters that belong to this organization. If you want to remove the organization, first remove the clusters."
       deny:
@@ -36,3 +37,6 @@ spec:
           operator: In
           value:
           - DELETE
+        - key: "{{clusterCount}}"
+          operator: GreaterThan
+          value: "0"


### PR DESCRIPTION
Apparently, the `context` is evaluated on every request. When an `Organization` is first reconciled after being created and we want to update its `status` field with its namespace, the request would fail because `request.oldObject.status` was not set (basically the `status` field is null at this point).

To workaround this issue, we add a default value like `{{request.oldObject.status.namespace || ''}}`. This won't break the policy on requests where the `status` field is null. And on `DELETE` requests, the `status` will be there so it will work normally.

### Checklist

- [X] Update changelog in CHANGELOG.md.
