### PR TITLE
Restrict cluster, machinepool and machinedeployment names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stop pushing to `openstack-app-collection`.
 
+### Added
+
+- Restrict cluster names to 10 characters and forbid them to start with a number.
+- Restrict machine pools and deployments to 21 characters (10 for the cluster
+name prefix, 1 for a delimiter '-' and 10 for the deployment/pool name itself)
+and forbid them to start with a number.
+
 ## [0.2.3] - 2023-04-25
 
 ### Changed

--- a/helm/kyverno-policies-ux/Chart.yaml
+++ b/helm/kyverno-policies-ux/Chart.yaml
@@ -4,7 +4,6 @@ appVersion: master
 description: Giant Swarm policies supporting user experience.
 icon: https://s.giantswarm.io/app-icons/kyverno/1/light.svg
 home: https://github.com/giantswarm/kyverno-policies-ux
-icon: https://s.giantswarm.io/app-icons/kyverno/1/light.svg
 annotations:
   application.giantswarm.io/team: "rainbow"
   config.giantswarm.io/version: 1.x.x

--- a/helm/kyverno-policies-ux/Chart.yaml
+++ b/helm/kyverno-policies-ux/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: kyverno-policies-ux
 appVersion: master
 description: Giant Swarm policies supporting user experience.
+icon: https://s.giantswarm.io/app-icons/kyverno/1/light.svg
 home: https://github.com/giantswarm/kyverno-policies-ux
 annotations:
   application.giantswarm.io/team: "rainbow"

--- a/helm/kyverno-policies-ux/templates/cluster-names.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-names.yaml
@@ -1,0 +1,43 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of Clusters
+    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/description: >-
+      Cluster names must not be longer than 10 characters and never
+      start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: cluster-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - Cluster
+    validate:
+      message: "cluster name must be no longer than 10 characters"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: GreaterThan
+            value: 10
+  - name: cluster-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - Cluster
+    validate:
+      message: "cluster name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} regex_match('^[0-9].*', '{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: Equals
+            value: true
+

--- a/helm/kyverno-policies-ux/templates/machine-deployment-names.yaml
+++ b/helm/kyverno-policies-ux/templates/machine-deployment-names.yaml
@@ -1,0 +1,44 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: machine-deployment-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of MachineDeployments
+    policies.kyverno.io/subject: MachineDeployments
+    policies.kyverno.io/description: >-
+      MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
+      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      and 10 for MACHINE_DEPLOYMENT_NAME).
+      In addition they must never start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: machine-deployment-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachineDeployment
+    validate:
+      message: "machine deployment name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: GreaterThan
+            value: 21
+  - name: machine-deployment-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachineDeployment
+    validate:
+      message: "machine deployment name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} regex_match('^[0-9].*', '{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: Equals
+            value: true

--- a/helm/kyverno-policies-ux/templates/machine-pool-names.yaml
+++ b/helm/kyverno-policies-ux/templates/machine-pool-names.yaml
@@ -1,0 +1,44 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of Clusters
+    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/description: >-
+      MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
+      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      and 10 for MACHINE_POOL_NAME).
+      In addition they must never start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: machine-pool-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachinePool
+    validate:
+      message: "machine pool name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: GreaterThan
+            value: 21
+  - name: machine-pool-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachinePool
+    validate:
+      message: "machine pool name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ `{{` }} regex_match('^[0-9].*', '{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
+            operator: Equals
+            value: true

--- a/helm/kyverno-policies-ux/templates/machine-pool-names.yaml
+++ b/helm/kyverno-policies-ux/templates/machine-pool-names.yaml
@@ -2,10 +2,10 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: cluster-names
+  name: restrict-machine-pool-names
   annotations:
-    policies.kyverno.io/title: Restrict names of Clusters
-    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/title: Restrict names of MachinePools
+    policies.kyverno.io/subject: MachinePools
     policies.kyverno.io/description: >-
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 21 (10 for CLUSTER_NAME

--- a/policies/ux/cluster-names.yaml
+++ b/policies/ux/cluster-names.yaml
@@ -1,0 +1,42 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of Clusters
+    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/description: >-
+      Cluster names must not be longer than 10 characters and never
+      start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: cluster-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - Cluster
+    validate:
+      message: "cluster name must be no longer than 10 characters"
+      deny:
+        conditions:
+          any:
+          - key: "{{ length('{{request.object.metadata.name}}') }}"
+            operator: GreaterThan
+            value: 10
+  - name: cluster-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - Cluster
+    validate:
+      message: "cluster name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ regex_match('^[0-9].*', '{{request.object.metadata.name}}') }}"
+            operator: Equals
+            value: true
+

--- a/policies/ux/machine-deployment-names.yaml
+++ b/policies/ux/machine-deployment-names.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: machine-deployment-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of MachineDeployments
+    policies.kyverno.io/subject: MachineDeployments
+    policies.kyverno.io/description: >-
+      MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
+      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      and 10 for MACHINE_DEPLOYMENT_NAME).
+      In addition they must never start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: machine-deployment-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachineDeployment
+    validate:
+      message: "machine deployment name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      deny:
+        conditions:
+          any:
+          - key: "{{ length('{{request.object.metadata.name}}') }}"
+            operator: GreaterThan
+            value: 21
+  - name: machine-deployment-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachineDeployment
+    validate:
+      message: "machine deployment name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ regex_match('^[0-9].*', '{{request.object.metadata.name}}') }}"
+            operator: Equals
+            value: true

--- a/policies/ux/machine-pool-names.yaml
+++ b/policies/ux/machine-pool-names.yaml
@@ -1,10 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: cluster-names
+  name: restrict-machine-pool-names
   annotations:
-    policies.kyverno.io/title: Restrict names of Clusters
-    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/title: Restrict names of MachinePools
+    policies.kyverno.io/subject: MachinePools
     policies.kyverno.io/description: >-
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 21 (10 for CLUSTER_NAME

--- a/policies/ux/machine-pool-names.yaml
+++ b/policies/ux/machine-pool-names.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-names
+  annotations:
+    policies.kyverno.io/title: Restrict names of Clusters
+    policies.kyverno.io/subject: Clusters
+    policies.kyverno.io/description: >-
+      MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
+      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      and 10 for MACHINE_POOL_NAME).
+      In addition they must never start with a number.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: machine-pool-name-maximum-length
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachinePool
+    validate:
+      message: "machine pool name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      deny:
+        conditions:
+          any:
+          - key: "{{ length('{{request.object.metadata.name}}') }}"
+            operator: GreaterThan
+            value: 21
+  - name: machine-pool-name-does-not-start-with-number
+    match:
+      any:
+      - resources:
+          kinds:
+          - MachinePool
+    validate:
+      message: "machine pool name must not start with a number"
+      deny:
+        conditions:
+          any:
+          - key: "{{ regex_match('^[0-9].*', '{{request.object.metadata.name}}') }}"
+            operator: Equals
+            value: true

--- a/tests/ats/invalid-clusters.yaml
+++ b/tests/ats/invalid-clusters.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  # forbidden: starts with a number
+  name: "0cluster"
+  namespace: default
+spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  # forbidden: longer than 10 characters
+  name: "a1234567890"
+  namespace: default
+spec: {}

--- a/tests/ats/invalid-machinedeployments.yaml
+++ b/tests/ats/invalid-machinedeployments.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  # forbidden: starts with a number
+  name: "0deploy"
+  namespace: default
+spec:
+  clusterName: test
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap: {}
+      infrastructureRef: {}
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  # forbidden: longer than 21 characters
+  name: "0123456789-0123456789a"
+  namespace: default
+spec:
+  clusterName: test
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap: {}
+      infrastructureRef: {}
+

--- a/tests/ats/invalid-machinepools.yaml
+++ b/tests/ats/invalid-machinepools.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  # forbidden: starts with a number
+  name: "0pool"
+  namespace: default
+spec:
+  clusterName: test
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap:
+        dataSecretName: test
+      infrastructureRef: {}
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  # forbidden: longer than 21 characters
+  name: "0123456789-0123456789a"
+  namespace: default
+spec:
+  clusterName: test
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap:
+        dataSecretName: test
+      infrastructureRef: {}

--- a/tests/ats/machinedeployment-crd.yaml
+++ b/tests/ats/machinedeployment-crd.yaml
@@ -1,0 +1,1480 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "MachineDeployment is the Schema for the machinedeployments API.
+          \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported
+                      strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.Data
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: "Data contains the bootstrap data, such as
+                              cloud-init details scripts. If nil, the Machine should
+                              remain in the Pending state. \n Deprecated: Switch to
+                              DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "MachineDeployment is the Schema for the machinedeployments API.
+          \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment
+                          to identify nodes to delete when downscaling. Valid values
+                          are "Random, "Newest", "Oldest" When no value is supplied,
+                          the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachineDeployment
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: "Number of desired machines. This is a pointer to distinguish
+                  between explicit zero and not specified. \n Defaults to: * if the
+                  Kubernetes autoscaler min size and max size annotations are set:
+                  - if it's a new MachineDeployment, use min size - if the replicas
+                  field of the old MachineDeployment is < min size, use min size -
+                  if the replicas field of the old MachineDeployment is > max size,
+                  use max size - if the replicas field of the old MachineDeployment
+                  is in the (min size, max size) range, keep the value from the oldMD
+                  * otherwise use 1 Note: Defaulting will be run whenever the replicas
+                  field is not set: * A new MachineDeployment is created with replicas
+                  not set. * On an existing MachineDeployment the replicas field was
+                  first set and is now unset. Those cases are especially relevant
+                  for the following Kubernetes autoscaler use cases: * A new MachineDeployment
+                  is created and replicas should be managed by the autoscaler * An
+                  existing MachineDeployment which initially wasn't controlled by
+                  the autoscaler should be later controlled by the autoscaler"
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: 'RolloutAfter is a field to indicate a rollout should
+                  be performed after the specified time even if no changes have been
+                  made to the MachineDeployment. Example: In the YAML the time can
+                  be specified in the RFC3339 format. To specify the rolloutAfter
+                  target as March 9, 2023, at 9 am UTC use "2023-03-09T09:00:00Z".'
+                format: date-time
+                type: string
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment
+                          to identify nodes to delete when downscaling. Valid values
+                          are "Random, "Newest", "Oldest" When no value is supplied,
+                          the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/tests/ats/machinepool-crd.yaml
+++ b/tests/ats/machinepool-crd.yaml
@@ -1,0 +1,1406 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: machinepools.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:
+          This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: The deployment strategy to use to replace existing machine
+                  instances with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported
+                      strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.Data
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: "Data contains the bootstrap data, such as
+                              cloud-init details scripts. If nil, the Machine should
+                              remain in the Pending state. \n Deprecated: Switch to
+                              DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:
+          This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachinePool
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/tests/ats/test-cluster.yaml
+++ b/tests/ats/test-cluster.yaml
@@ -2,21 +2,21 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster
+  name: test
   namespace: default
   labels:
     release.giantswarm.io/version: 1.2.3
-    giantswarm.io/cluster: test-cluster
-    cluster.x-k8s.io/cluster-name: test-cluster
+    giantswarm.io/cluster: test
+    cluster.x-k8s.io/cluster-name: test
 spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster-organization-blocker
+  name: org-block
   namespace: org-giantswarm
   labels:
     release.giantswarm.io/version: 1.2.3
-    giantswarm.io/cluster: test-cluster-organization-blocker
-    cluster.x-k8s.io/cluster-name: test-cluster-organization-blocker
+    giantswarm.io/cluster: org-block
+    cluster.x-k8s.io/cluster-name: org-block
 spec: {}

--- a/tests/ats/test_fixtures.py
+++ b/tests/ats/test_fixtures.py
@@ -20,6 +20,12 @@ def fixtures(kube_cluster: Cluster):
     LOGGER.info("Create cluster.x-k8s.io CRD")
     ret = kube_cluster.kubectl("apply", filename="cluster-crd.yaml", output_format="json")
     LOGGER.debug("Created cluster CRD")
+    LOGGER.info("Create machinepools.cluster.x-k8s.io CRD")
+    ret = kube_cluster.kubectl("apply", filename="machinepool-crd.yaml", output_format="json")
+    LOGGER.debug("Created machinepool CRD")
+    LOGGER.info("Create machinedeployments.cluster.x-k8s.io CRD")
+    ret = kube_cluster.kubectl("apply", filename="machinedeployment-crd.yaml", output_format="json")
+    LOGGER.debug("Created machinedeployment CRD")
 
     # Organization CRD
     LOGGER.info("Create Organization CRD")
@@ -38,6 +44,8 @@ def fixtures(kube_cluster: Cluster):
     LOGGER.debug(f"Created cluster service priority policies result: {ret}")
     ret = kube_cluster.kubectl("apply", filename="../../policies/ux/organization-deletion-when-has-clusters.yaml", output_format="json")
     LOGGER.debug(f"Created organization deletion policies result: {ret}")
+    ret = kube_cluster.kubectl("apply", filename="../../policies/ux/cluster-names.yaml", output_format="json")
+    LOGGER.debug(f"Created cluster names policies result: {ret}")
 
     # Create Organization namespace
     LOGGER.info("Create namespaces named 'org-giantswarm' and 'org-empty'")

--- a/tests/ats/test_fixtures.py
+++ b/tests/ats/test_fixtures.py
@@ -5,6 +5,8 @@ import pykube
 import pytest
 import time
 
+
+TEST_CLUSTER_NAME = "test"
 LOGGER = logging.getLogger(__name__)
 
 # TODO: Can we take this from a central config to avoid repetition?
@@ -46,6 +48,10 @@ def fixtures(kube_cluster: Cluster):
     LOGGER.debug(f"Created organization deletion policies result: {ret}")
     ret = kube_cluster.kubectl("apply", filename="../../policies/ux/cluster-names.yaml", output_format="json")
     LOGGER.debug(f"Created cluster names policies result: {ret}")
+    ret = kube_cluster.kubectl("apply", filename="../../policies/ux/machine-deployment-names.yaml", output_format="json")
+    LOGGER.debug(f"Created machine deployment names policies result: {ret}")
+    ret = kube_cluster.kubectl("apply", filename="../../policies/ux/machine-pool-names.yaml", output_format="json")
+    LOGGER.debug(f"Created machine pool names policies result: {ret}")
 
     # Create Organization namespace
     LOGGER.info("Create namespaces named 'org-giantswarm' and 'org-empty'")
@@ -62,7 +68,7 @@ def fixtures(kube_cluster: Cluster):
     # LOGGER.debug(f"Patched empty organization status with namespace: {ret}")
 
     # Test cluster CR
-    LOGGER.info("Create cluster.x-k8s.io/v1beta1 named 'test-cluster'")
+    LOGGER.info(f"Create cluster.x-k8s.io/v1beta1 named '{TEST_CLUSTER_NAME}'")
     ret = kube_cluster.kubectl("apply", filename="test-cluster.yaml", output_format="json")
     LOGGER.debug(f"Created cluster result: {ret}")
 

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -62,11 +62,7 @@ def test_service_priority_cluster_label_valid_edit(fixtures, kube_cluster: Clust
 
 
 @pytest.mark.smoke
-<<<<<<< HEAD
-def test_service_priority_cluster_label_invalid_edit(fixtures, kube_cluster: Cluster) -> None:
-=======
 def test_service_priority_cluster_label_invalid_edit(fixtures, capfd, kube_cluster: Cluster) -> None:
->>>>>>> main
     with pytest.raises(subprocess.CalledProcessError):
         """
         Checks whether our policy to prevent invalid service-priority label
@@ -76,30 +72,14 @@ def test_service_priority_cluster_label_invalid_edit(fixtures, capfd, kube_clust
         # Set valid label value
         LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
         cluster = kube_cluster.kubectl(
-<<<<<<< HEAD
             f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=medium"
-=======
-            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
->>>>>>> main
         )
         LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
 
         # Set invalid label value
         LOGGER.info("Attempt to set invalid service-priority label")
-<<<<<<< HEAD
-        output = subprocess.check_output(
-            kube_cluster.kubectl(
-                f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
-            ),
-            stderr=subprocess.STDOUT
-        )
-        LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-        assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-        assert SERVICE_PRIORITY_LABEL in output
-        assert "validate.kyverno.svc-fail" in output
-=======
         output = kube_cluster.kubectl(
-            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
+            f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
         )
         LOGGER.warn(f"Setting invalid service-priority label did not fail, output: {output}")
 
@@ -108,7 +88,6 @@ def test_service_priority_cluster_label_invalid_edit(fixtures, capfd, kube_clust
     assert SERVICE_PRIORITY_LABEL in stderr
     assert "restrict-label-value-changes" in stderr
     assert "validate.kyverno.svc-fail" in stderr
->>>>>>> main
 
 
 @pytest.mark.smoke
@@ -133,11 +112,7 @@ def test_service_priority_cluster_label_remove(fixtures, kube_cluster: Cluster) 
 
 
 @pytest.mark.smoke
-<<<<<<< HEAD
-def test_service_priority_cluster_label_invalid_set(fixtures, kube_cluster: Cluster) -> None:
-=======
 def test_service_priority_cluster_label_invalid_set(fixtures, capfd, kube_cluster: Cluster) -> None:
->>>>>>> main
     with pytest.raises(subprocess.CalledProcessError):
         """
         Checks whether our policy to prevent invalid service-priority label
@@ -146,17 +121,16 @@ def test_service_priority_cluster_label_invalid_set(fixtures, capfd, kube_cluste
 
         # Set invalid label value
         LOGGER.info("Attempt to set invalid service-priority label")
-<<<<<<< HEAD
-        output = subprocess.check_output(
-            kube_cluster.kubectl(
-                f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
-            ),
-            stderr=subprocess.STDOUT
+        output = kube_cluster.kubectl(
+            f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
         )
-        LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-        assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-        assert SERVICE_PRIORITY_LABEL in output
-        assert "validate.kyverno.svc-fail" in output
+        LOGGER.warn(f"Setting invalid service-priority label did not fail, output: {output}")
+
+    _, stderr = capfd.readouterr()
+
+    assert SERVICE_PRIORITY_LABEL in stderr
+    assert "restrict-label-value-changes" in stderr
+    assert "validate.kyverno.svc-fail" in stderr
 
 
 @pytest.mark.smoke
@@ -248,96 +222,6 @@ def test_invalid_machinedeployment_name(fixtures, capfd, kube_cluster: Cluster) 
     _, stderr = capfd.readouterr()
     assert "machine-deployment-name-maximum-length" in stderr
     assert "machine-deployment-name-does-not-start-with-number" in stderr
-
-
-@pytest.mark.smoke
-@pytest.mark.capture_disabled
-def test_invalid_cluster_name(fixtures, capfd, kube_cluster: Cluster) -> None:
-    with pytest.raises(subprocess.CalledProcessError):
-        """
-        Checks whether our policy prevents creating Cluster resources with
-        invalid names.
-        """
-
-        # Set invalid label value
-        LOGGER.info("Attempt to create cluster with invalid name")
-        output = subprocess.check_output(
-                kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json"), 
-                stderr=subprocess.STDOUT
-        )
-        LOGGER.info(f"Attempt to create cluster with invalid name - result: {output}")
-        assert "cluster-name-maximum-length" in output
-
-        # LOGGER.info("Attempt to create cluster with invalid name")
-        # # with pytest.raises(subprocess.CalledProcessError) as e:
-        # # with pytest.raises(Exception) as e:
-        # LOGGER.info(f"Attempt to create cluster with invalid name")
-        # try:
-        #     output = subprocess.check_output(
-        #         kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json"),
-        #         stderr=subprocess.STDOUT
-        #     )
-        # except subprocess.CalledProcessError as e:
-        #     LOGGER.info(f"After kubectl e: {e}")
-        # stdout, stderr = capfd.readouterr()
-        # LOGGER.info(f"captured stdout: {stdout}")
-        # LOGGER.info(f"captured stderr: {stderr}")
-        #
-        # with capfd.disabled():
-        #     LOGGER.info("works")
-        # try:
-        #     output = kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json")
-        #     assert False  # should raise exception
-        # except subprocess.CalledProcessError as e:
-        #     LOGGER.info("After kubectl - subprocess.CalledProcessError")
-        #     LOGGER.info(f"Attempted to create cluster with invalid name: {e}")
-        #     LOGGER.info(f"Stdout: {e.stdout}")
-        #     LOGGER.info(f"Stderr: {e.stdout}")
-        #     assert "cluster-name-maximum-length" in str(e)
-
-
-
-# @pytest.mark.smoke
-# def test_invalid_machinepool_name(fixtures, kube_cluster: Cluster) -> None:
-#     with pytest.raises(subprocess.CalledProcessError):
-#         """
-#         Checks whether our policy prevents creating MachinePool resources with
-#         invalid names.
-#         """
-#
-#         LOGGER.info("Attempt to create machinepool with invalid name")
-#         with pytest.raises(subprocess.CalledProcessError) as e:
-#             LOGGER.info(f"Attempt to create machinepool with invalid name - result: {e}")
-#             output = kube_cluster.kubectl("apply", filename="invalid-machinepools.yaml", output_format="json")
-#             assert "machinepool-name-maximum-length" in str(e.value)
-#
-#
-# @pytest.mark.smoke
-# def test_invalid_machinedeployment_name(fixtures, kube_cluster: Cluster) -> None:
-#     with pytest.raises(subprocess.CalledProcessError):
-#         """
-#         Checks whether our policy prevents creating MachineDeployment resources with
-#         invalid names.
-#         """
-#
-#         LOGGER.info("Attempt to create machinedeployment with invalid name")
-#         with pytest.raises(subprocess.CalledProcessError) as e:
-#             LOGGER.info(f"Attempt to create machinedeployment with invalid name - result: {e}")
-#             output = kube_cluster.kubectl("apply", filename="invalid-machinedeployments.yaml", output_format="json")
-#             assert "machinedeployment-name-maximum-length" in str(e.value)
-=======
-        output = kube_cluster.kubectl(
-            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
-        )
-        LOGGER.warn(f"Setting invalid service-priority label did not fail, output: {output}")
-
-    _, stderr = capfd.readouterr()
-
-    assert SERVICE_PRIORITY_LABEL in stderr
-    assert "restrict-label-value-changes" in stderr
-    assert "validate.kyverno.svc-fail" in stderr
->>>>>>> main
-
 
 # @pytest.mark.smoke
 # def test_block_organization_deletion_when_still_has_clusters(fixtures, kube_cluster: Cluster) -> None:

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -1,5 +1,5 @@
 from pytest_helm_charts.clusters import Cluster
-from test_fixtures import fixtures
+from test_fixtures import fixtures, TEST_CLUSTER_NAME
 import logging
 import pykube
 import pytest
@@ -9,6 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 SERVICE_PRIORITY_LABEL = "giantswarm.io/service-priority"
 
+
 @pytest.mark.smoke
 def test_api_working(fixtures, kube_cluster: Cluster) -> None:
     """
@@ -17,10 +18,11 @@ def test_api_working(fixtures, kube_cluster: Cluster) -> None:
     assert kube_cluster.kube_client is not None
     assert len(pykube.Node.objects(kube_cluster.kube_client)) >= 1
 
-    LOGGER.info("Adding label mylabel=myvalue to cluster test-cluster")
+    LOGGER.info(f"Adding label mylabel=myvalue to cluster {TEST_CLUSTER_NAME}")
     kube_cluster.kubectl(
-        "label --overwrite clusters.cluster.x-k8s.io test-cluster mylabel=myvalue"
+        f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} mylabel=myvalue"
     )
+
 
 @pytest.mark.smoke
 def test_service_priority_cluster_label_valid_set(fixtures, kube_cluster: Cluster) -> None:
@@ -32,7 +34,7 @@ def test_service_priority_cluster_label_valid_set(fixtures, kube_cluster: Cluste
     # Set valid label value
     LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
     cluster = kube_cluster.kubectl(
-        f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
+        f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=medium"
     )
     LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
 
@@ -47,45 +49,45 @@ def test_service_priority_cluster_label_valid_edit(fixtures, kube_cluster: Clust
     # Set valid label value
     LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
     cluster = kube_cluster.kubectl(
-        f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
+        f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=medium"
     )
     LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
 
     # Edit label value
     LOGGER.info(f"Attempt to edit {SERVICE_PRIORITY_LABEL} label")
     cluster = kube_cluster.kubectl(
-        f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=lowest"
+        f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=lowest"
     )
     LOGGER.info(f"Attempt to edit service-priority label - result: {cluster}")
 
 
 @pytest.mark.smoke
 def test_service_priority_cluster_label_invalid_edit(fixtures, kube_cluster: Cluster) -> None:
-  with pytest.raises(subprocess.CalledProcessError):
-      """
-      Checks whether our policy to prevent invalid service-priority label
-      values is working.
-      """
-  
-      # Set valid label value
-      LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
-      cluster = kube_cluster.kubectl(
-          f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
-      )
-      LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
-  
-      # Set invalid label value
-      LOGGER.info("Attempt to set invalid service-priority label")
-      output = subprocess.check_output(
-          kube_cluster.kubectl(
-              f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
-              ),
-          stderr=subprocess.STDOUT
-      )
-      LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-      assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-      assert SERVICE_PRIORITY_LABEL in output
-      assert "validate.kyverno.svc-fail" in output
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy to prevent invalid service-priority label
+        values is working.
+        """
+
+        # Set valid label value
+        LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
+        cluster = kube_cluster.kubectl(
+            f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=medium"
+        )
+        LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
+
+        # Set invalid label value
+        LOGGER.info("Attempt to set invalid service-priority label")
+        output = subprocess.check_output(
+            kube_cluster.kubectl(
+                f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
+            ),
+            stderr=subprocess.STDOUT
+        )
+        LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
+        assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
+        assert SERVICE_PRIORITY_LABEL in output
+        assert "validate.kyverno.svc-fail" in output
 
 
 @pytest.mark.smoke
@@ -98,37 +100,128 @@ def test_service_priority_cluster_label_remove(fixtures, kube_cluster: Cluster) 
     # Set valid label value
     LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
     cluster = kube_cluster.kubectl(
-        f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=highest"
+        f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=highest"
     )
     LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
 
     # Remove label
     cluster = kube_cluster.kubectl(
-        f"label clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}-"
+        f"label clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}-"
     )
     assert SERVICE_PRIORITY_LABEL not in cluster["metadata"]["labels"]
 
 
 @pytest.mark.smoke
 def test_service_priority_cluster_label_invalid_set(fixtures, kube_cluster: Cluster) -> None:
-  with pytest.raises(subprocess.CalledProcessError):
-      """
-      Checks whether our policy to prevent invalid service-priority label
-      values is working.
-      """
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy to prevent invalid service-priority label
+        values is working.
+        """
 
-      # Set invalid label value
-      LOGGER.info("Attempt to set invalid service-priority label")
-      output = subprocess.check_output(
-          kube_cluster.kubectl(
-              f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
-              ),
-          stderr=subprocess.STDOUT
-      )
-      LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-      assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-      assert SERVICE_PRIORITY_LABEL in output
-      assert "validate.kyverno.svc-fail" in output
+        # Set invalid label value
+        LOGGER.info("Attempt to set invalid service-priority label")
+        output = subprocess.check_output(
+            kube_cluster.kubectl(
+                f"label --overwrite clusters.cluster.x-k8s.io {TEST_CLUSTER_NAME} {SERVICE_PRIORITY_LABEL}=badvalue"
+            ),
+            stderr=subprocess.STDOUT
+        )
+        LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
+        assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
+        assert SERVICE_PRIORITY_LABEL in output
+        assert "validate.kyverno.svc-fail" in output
+
+
+@pytest.mark.smoke
+def test_valid_cluster_name(fixtures, kube_cluster: Cluster) -> None:
+    LOGGER.info("Attempt to create cluster with valid name")
+    output = kube_cluster.kubectl(
+        "apply",
+        filename="valid-cluster.yaml",
+        output_format="json"
+    ),
+    LOGGER.info(f"Created cluster without error, result: {output}")
+
+
+@pytest.mark.smoke
+def test_valid_machinepool_name(fixtures, kube_cluster: Cluster) -> None:
+    LOGGER.info("Attempt to create machinepool with valid name")
+    output = kube_cluster.kubectl(
+        "apply",
+        filename="valid-machinepool.yaml",
+        output_format="json"
+    ),
+    LOGGER.info(f"Created machinepool without error, result: {output}")
+
+
+@pytest.mark.smoke
+def test_valid_machinedeployment_name(fixtures, kube_cluster: Cluster) -> None:
+    LOGGER.info("Attempt to create machinedeployment with valid name")
+    output = kube_cluster.kubectl(
+        "apply",
+        filename="valid-machinedeployment.yaml",
+        output_format="json"
+    ),
+    LOGGER.info(f"Created machinedeployment without error, result: {output}")
+
+
+@pytest.mark.smoke
+def test_invalid_cluster_name(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy prevents creating Cluster resources with
+        invalid names.
+        """
+
+        # Set invalid label value
+        LOGGER.info("Attempt to create cluster with invalid name")
+        output = kube_cluster.kubectl(
+            "apply",
+            filename="invalid-clusters.yaml",
+            output_format="json"
+        ),
+        LOGGER.warn(f"Creating cluster did not fail as expected, result: {output}")
+
+    _, stderr = capfd.readouterr()
+    assert "validate.kyverno.svc-fail" in stderr
+    assert "cluster-name-maximum-length" in stderr
+    assert "cluster-name-does-not-start-with-number" in stderr
+
+
+@pytest.mark.smoke
+def test_invalid_machinepool_name(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy prevents creating MachinePool resources with
+        invalid names.
+        """
+
+        LOGGER.info("Attempt to create machinepool with invalid name")
+        output = kube_cluster.kubectl("apply", filename="invalid-machinepools.yaml", output_format="json"),
+        LOGGER.warn(f"Creating machinepool did not fail as expected, result: {output}")
+
+    _, stderr = capfd.readouterr()
+    assert "validate.kyverno.svc-fail" in stderr
+    assert "machine-pool-name-maximum-length" in stderr
+    assert "machine-pool-name-does-not-start-with-number" in stderr
+
+
+@pytest.mark.smoke
+def test_invalid_machinedeployment_name(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy prevents creating MachineDeployment resources with
+        invalid names.
+        """
+
+        LOGGER.info("Attempt to create machinedeployment with invalid name")
+        output = kube_cluster.kubectl("apply", filename="invalid-machinedeployments.yaml", output_format="json"),
+        LOGGER.warn(f"Creating machinedeployment did not fail as expected, result: {output}")
+
+    _, stderr = capfd.readouterr()
+    assert "machine-deployment-name-maximum-length" in stderr
+    assert "machine-deployment-name-does-not-start-with-number" in stderr
 
 
 @pytest.mark.smoke

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -131,6 +131,83 @@ def test_service_priority_cluster_label_invalid_set(fixtures, kube_cluster: Clus
       assert "validate.kyverno.svc-fail" in output
 
 
+@pytest.mark.smoke
+@pytest.mark.capture_disabled
+def test_invalid_cluster_name(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy prevents creating Cluster resources with
+        invalid names.
+        """
+
+        # Set invalid label value
+        LOGGER.info("Attempt to create cluster with invalid name")
+        output = subprocess.check_output(
+                kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json"), 
+                stderr=subprocess.STDOUT
+        )
+        LOGGER.info(f"Attempt to create cluster with invalid name - result: {output}")
+        assert "cluster-name-maximum-length" in output
+
+        # LOGGER.info("Attempt to create cluster with invalid name")
+        # # with pytest.raises(subprocess.CalledProcessError) as e:
+        # # with pytest.raises(Exception) as e:
+        # LOGGER.info(f"Attempt to create cluster with invalid name")
+        # try:
+        #     output = subprocess.check_output(
+        #         kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json"),
+        #         stderr=subprocess.STDOUT
+        #     )
+        # except subprocess.CalledProcessError as e:
+        #     LOGGER.info(f"After kubectl e: {e}")
+        # stdout, stderr = capfd.readouterr()
+        # LOGGER.info(f"captured stdout: {stdout}")
+        # LOGGER.info(f"captured stderr: {stderr}")
+        #
+        # with capfd.disabled():
+        #     LOGGER.info("works")
+        # try:
+        #     output = kube_cluster.kubectl("apply", filename="invalid-clusters.yaml", output_format="json")
+        #     assert False  # should raise exception
+        # except subprocess.CalledProcessError as e:
+        #     LOGGER.info("After kubectl - subprocess.CalledProcessError")
+        #     LOGGER.info(f"Attempted to create cluster with invalid name: {e}")
+        #     LOGGER.info(f"Stdout: {e.stdout}")
+        #     LOGGER.info(f"Stderr: {e.stdout}")
+        #     assert "cluster-name-maximum-length" in str(e)
+
+
+
+# @pytest.mark.smoke
+# def test_invalid_machinepool_name(fixtures, kube_cluster: Cluster) -> None:
+#     with pytest.raises(subprocess.CalledProcessError):
+#         """
+#         Checks whether our policy prevents creating MachinePool resources with
+#         invalid names.
+#         """
+#
+#         LOGGER.info("Attempt to create machinepool with invalid name")
+#         with pytest.raises(subprocess.CalledProcessError) as e:
+#             LOGGER.info(f"Attempt to create machinepool with invalid name - result: {e}")
+#             output = kube_cluster.kubectl("apply", filename="invalid-machinepools.yaml", output_format="json")
+#             assert "machinepool-name-maximum-length" in str(e.value)
+#
+#
+# @pytest.mark.smoke
+# def test_invalid_machinedeployment_name(fixtures, kube_cluster: Cluster) -> None:
+#     with pytest.raises(subprocess.CalledProcessError):
+#         """
+#         Checks whether our policy prevents creating MachineDeployment resources with
+#         invalid names.
+#         """
+#
+#         LOGGER.info("Attempt to create machinedeployment with invalid name")
+#         with pytest.raises(subprocess.CalledProcessError) as e:
+#             LOGGER.info(f"Attempt to create machinedeployment with invalid name - result: {e}")
+#             output = kube_cluster.kubectl("apply", filename="invalid-machinedeployments.yaml", output_format="json")
+#             assert "machinedeployment-name-maximum-length" in str(e.value)
+
+
 # @pytest.mark.smoke
 # def test_block_organization_deletion_when_still_has_clusters(fixtures, kube_cluster: Cluster) -> None:
 #   with pytest.raises(subprocess.CalledProcessError):

--- a/tests/ats/valid-cluster.yaml
+++ b/tests/ats/valid-cluster.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "cluster"
+  namespace: default
+spec: {}

--- a/tests/ats/valid-machinedeployment.yaml
+++ b/tests/ats/valid-machinedeployment.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "deploy"
+  namespace: default
+spec:
+  clusterName: test
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap: {}
+      infrastructureRef: {}
+

--- a/tests/ats/valid-machinepool.yaml
+++ b/tests/ats/valid-machinepool.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "pool"
+  namespace: default
+spec:
+  clusterName: test
+  template:
+    metadata:
+      labels: {}
+    spec:
+      clusterName: test
+      bootstrap:
+        dataSecretName: test
+      infrastructureRef: {}


### PR DESCRIPTION
This PR introduces three policies:
- `.metadata.name` in Clusters
  - <= 10 characters
  - does not start with a number
- `.metadata.name` in MachineDeployments
  - <= 21 characters (10 for the cluster name as a prefix, 1 for the delimiter `-` and 10 for the name itself)
  - does not start with a number
- `.metadata.name` in MachinePools
  - <= 21 characters  (10 for the cluster name as a prefix, 1 for the delimiter `-` and 10 for the name itself)
  - does not start with a number
  
Closes https://github.com/giantswarm/roadmap/issues/1017

I tested the changes on golem (capa) and gaia (aws).

### Checklist

- [x] Update changelog in CHANGELOG.md.
