### PR TITLE
Fix cluster label tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stop pushing to `openstack-app-collection`.
 
+### Changed
+
+- Improve/fix cluster label policy tests to also check error message.
+
 ## [0.2.3] - 2023-04-25
 
 ### Changed

--- a/helm/kyverno-policies-ux/Chart.yaml
+++ b/helm/kyverno-policies-ux/Chart.yaml
@@ -3,6 +3,7 @@ name: kyverno-policies-ux
 appVersion: master
 description: Giant Swarm policies supporting user experience.
 home: https://github.com/giantswarm/kyverno-policies-ux
+icon: https://s.giantswarm.io/app-icons/kyverno/1/light.svg
 annotations:
   application.giantswarm.io/team: "rainbow"
   config.giantswarm.io/version: 1.x.x

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -84,6 +84,7 @@ def test_service_priority_cluster_label_invalid_edit(fixtures, capfd, kube_clust
     _, stderr = capfd.readouterr()
 
     assert SERVICE_PRIORITY_LABEL in stderr
+    assert "restrict-label-value-changes" in stderr
     assert "validate.kyverno.svc-fail" in stderr
 
 
@@ -126,6 +127,7 @@ def test_service_priority_cluster_label_invalid_set(fixtures, capfd, kube_cluste
     _, stderr = capfd.readouterr()
 
     assert SERVICE_PRIORITY_LABEL in stderr
+    assert "restrict-label-value-changes" in stderr
     assert "validate.kyverno.svc-fail" in stderr
 
 

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -60,32 +60,31 @@ def test_service_priority_cluster_label_valid_edit(fixtures, kube_cluster: Clust
 
 
 @pytest.mark.smoke
-def test_service_priority_cluster_label_invalid_edit(fixtures, kube_cluster: Cluster) -> None:
-  with pytest.raises(subprocess.CalledProcessError):
-      """
-      Checks whether our policy to prevent invalid service-priority label
-      values is working.
-      """
-  
-      # Set valid label value
-      LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
-      cluster = kube_cluster.kubectl(
-          f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
-      )
-      LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
-  
-      # Set invalid label value
-      LOGGER.info("Attempt to set invalid service-priority label")
-      output = subprocess.check_output(
-          kube_cluster.kubectl(
-              f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
-              ),
-          stderr=subprocess.STDOUT
-      )
-      LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-      assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-      assert SERVICE_PRIORITY_LABEL in output
-      assert "validate.kyverno.svc-fail" in output
+def test_service_priority_cluster_label_invalid_edit(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy to prevent invalid service-priority label
+        values is working.
+        """
+
+        # Set valid label value
+        LOGGER.info(f"Attempt to set valid {SERVICE_PRIORITY_LABEL} label")
+        cluster = kube_cluster.kubectl(
+            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=medium"
+        )
+        LOGGER.info(f"Attempt to set valid service-priority label - result: {cluster}")
+
+        # Set invalid label value
+        LOGGER.info("Attempt to set invalid service-priority label")
+        output = kube_cluster.kubectl(
+            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
+        )
+        LOGGER.warn(f"Setting invalid service-priority label did not fail, output: {output}")
+
+    _, stderr = capfd.readouterr()
+
+    assert SERVICE_PRIORITY_LABEL in stderr
+    assert "validate.kyverno.svc-fail" in stderr
 
 
 @pytest.mark.smoke
@@ -110,25 +109,24 @@ def test_service_priority_cluster_label_remove(fixtures, kube_cluster: Cluster) 
 
 
 @pytest.mark.smoke
-def test_service_priority_cluster_label_invalid_set(fixtures, kube_cluster: Cluster) -> None:
-  with pytest.raises(subprocess.CalledProcessError):
-      """
-      Checks whether our policy to prevent invalid service-priority label
-      values is working.
-      """
+def test_service_priority_cluster_label_invalid_set(fixtures, capfd, kube_cluster: Cluster) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        """
+        Checks whether our policy to prevent invalid service-priority label
+        values is working.
+        """
 
-      # Set invalid label value
-      LOGGER.info("Attempt to set invalid service-priority label")
-      output = subprocess.check_output(
-          kube_cluster.kubectl(
-              f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
-              ),
-          stderr=subprocess.STDOUT
-      )
-      LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
-      assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
-      assert SERVICE_PRIORITY_LABEL in output
-      assert "validate.kyverno.svc-fail" in output
+        # Set invalid label value
+        LOGGER.info("Attempt to set invalid service-priority label")
+        output = kube_cluster.kubectl(
+            f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
+        )
+        LOGGER.warn(f"Setting invalid service-priority label did not fail, output: {output}")
+
+    _, stderr = capfd.readouterr()
+
+    assert SERVICE_PRIORITY_LABEL in stderr
+    assert "validate.kyverno.svc-fail" in stderr
 
 
 # @pytest.mark.smoke


### PR DESCRIPTION
While working on https://github.com/giantswarm/kyverno-policies-ux/pull/38 I realized that the existing tests were not working as intended. 
In some of the tests Kyverno denies the request made through kubectl, which results in an Exception.
The exception stops the execution of the code and the assertion after the call to kubectl were never checked.
```python
with pytest.raises(subprocess.CalledProcessError):
      # code collapsed...

      # next line throws an exception
      output = subprocess.check_output(
          kube_cluster.kubectl(
              f"label --overwrite clusters.cluster.x-k8s.io test-cluster {SERVICE_PRIORITY_LABEL}=badvalue"
              ),
          stderr=subprocess.STDOUT
      )
      # this is never reached
      LOGGER.info(f"Attempt to set invalid service-priority label - result: {cluster}")
      assert cluster["metadata"]["labels"][SERVICE_PRIORITY_LABEL] != "badvalue"
      assert SERVICE_PRIORITY_LABEL in output
      assert "validate.kyverno.svc-fail" in output
```

I changed the code so that the error messages given by kubectl are explicitly checked for the expected keywords.


### Checklist

- [x] Update changelog in CHANGELOG.md.

