### PR TITLE
Add configmap and secret to default resources for prevent deletion label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add ConfigMap and Secret as default targeted resource for `giantswarm.io/prevent-deletion` label.
+
+### Added
+
 - Add policy that blocks deletion of resources with the `giantswarm.io/prevent-deletion` label.
 
 ### Changed

--- a/helm/kyverno-policies-ux/templates/resource-deletion-when-has-prevent-deletion-label.yaml
+++ b/helm/kyverno-policies-ux/templates/resource-deletion-when-has-prevent-deletion-label.yaml
@@ -26,7 +26,6 @@ spec:
             - {{ . }}
 {{- end }}
 {{- end }}
-            - Namespace
           selector:
             matchLabels:
               giantswarm.io/prevent-deletion: "*"

--- a/helm/kyverno-policies-ux/values.yaml
+++ b/helm/kyverno-policies-ux/values.yaml
@@ -17,3 +17,6 @@ preventDeletionLabelPolicy:
     - infrastructure.cluster.x-k8s.io/v1beta1/VSphereCluster
     - application.giantswarm.io/v1alpha1/App
     - security.giantswarm.io/v1alpha1/Organization
+    - v1/Namespace
+    - v1/Secret
+    - v1/ConfigMap

--- a/policies/ux/resource-deletion-when-has-prevent-deletion-label.yaml
+++ b/policies/ux/resource-deletion-when-has-prevent-deletion-label.yaml
@@ -25,7 +25,6 @@ spec:
             - [[ . ]]
 [[- end ]]
 [[- end ]]
-            - Namespace
           selector:
             matchLabels:
               giantswarm.io/prevent-deletion: "*"


### PR DESCRIPTION
This PR adds ConfigMap and Secret as targeted resources for the prevent deletion label by default.

### Checklist

- [x] Update changelog in CHANGELOG.md.
