### PR TITLE
Specify resources without group and version

### DIFF
--- a/helm/kyverno-policies-ux/templates/resource-deletion-when-has-prevent-deletion-label.yaml
+++ b/helm/kyverno-policies-ux/templates/resource-deletion-when-has-prevent-deletion-label.yaml
@@ -22,9 +22,12 @@ spec:
       - resources:
           kinds: 
 {{- range .Values.preventDeletionLabelPolicy.resources }}
-{{- if $.Capabilities.APIVersions.Has . }}
-            - {{ . }}
-{{- end }}
+  {{- $resource := . -}}
+  {{- range $.Capabilities.APIVersions }}
+    {{- if eq (last (splitList "/" .)) $resource }}
+          - {{ $resource }}
+    {{- end }}
+  {{- end }}
 {{- end }}
           selector:
             matchLabels:

--- a/helm/kyverno-policies-ux/values.yaml
+++ b/helm/kyverno-policies-ux/values.yaml
@@ -6,17 +6,17 @@ provider:
 
 preventDeletionLabelPolicy:
   resources:
-    - cluster.x-k8s.io/v1beta1/Cluster
-    - cluster.x-k8s.io/v1beta1/MachineDeployment
-    - cluster.x-k8s.io/v1beta1/MachinePool
-    - infrastructure.giantswarm.io/v1alpha3/AWSCluster
-    - infrastructure.giantswarm.io/v1alpha3/AWSControlPlane
-    - infrastructure.giantswarm.io/v1alpha3/AWSMachineDeployment
-    - infrastructure.giantswarm.io/v1alpha3/G8sControlPlane
-    - infrastructure.cluster.x-k8s.io/v1beta1/AzureMachinePool
-    - infrastructure.cluster.x-k8s.io/v1beta1/VSphereCluster
-    - application.giantswarm.io/v1alpha1/App
-    - security.giantswarm.io/v1alpha1/Organization
-    - v1/Namespace
-    - v1/Secret
-    - v1/ConfigMap
+    - Cluster
+    - MachineDeployment
+    - MachinePool
+    - AWSCluster
+    - AWSControlPlane
+    - AWSMachineDeployment
+    - G8sControlPlane
+    - AzureMachinePool
+    - VSphereCluster
+    - App
+    - Organization
+    - Namespace
+    - Secret
+    - ConfigMap

--- a/policies/ux/resource-deletion-when-has-prevent-deletion-label.yaml
+++ b/policies/ux/resource-deletion-when-has-prevent-deletion-label.yaml
@@ -21,9 +21,12 @@ spec:
       - resources:
           kinds: 
 [[- range .Values.preventDeletionLabelPolicy.resources ]]
-[[- if $.Capabilities.APIVersions.Has . ]]
-            - [[ . ]]
-[[- end ]]
+  [[- $resource := . -]]
+  [[- range $.Capabilities.APIVersions ]]
+    [[- if eq (last (splitList "/" .)) $resource ]]
+          - [[ $resource ]]
+    [[- end ]]
+  [[- end ]]
 [[- end ]]
           selector:
             matchLabels:

--- a/tests/ats/test_fixtures.py
+++ b/tests/ats/test_fixtures.py
@@ -52,7 +52,7 @@ def fixtures(kube_cluster: Cluster):
         obj_names=["kyverno"],
         objs_namespace="kyverno",
         obj_condition_func=lambda d: int(d.obj["status"].get("readyReplicas", 0)) > 0,
-        timeout_sec=100,
+        timeout_sec=180,
         missing_ok=False
     )
     LOGGER.debug(f"Install Kyverno result: {ret}")


### PR DESCRIPTION
This PR allows users to specify the resources the prevent deletion policy
should target just by the name.

This makes the targeting less explicit, which has the advantage, that the user
does not have to react in case of a version bump.
Also less explicit targeting does not have any disadvantage in this case,
because the policy originally was designed to target all resources, as it is
only functional if the label is present.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
