### PR TITLE
Cluster name length to 20 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase the cluster name length to 20 characters
+- Increase the machine pool name size to 31 characters
+- Increase the machine deployment name size to 31 characters
+
 ## [0.7.0] - 2023-09-27
 
 ### Changed

--- a/helm/kyverno-policies-ux/templates/cluster-names.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-names.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/title: Restrict names of Clusters
     policies.kyverno.io/subject: Clusters
     policies.kyverno.io/description: >-
-      Cluster names must not be longer than 10 characters and never
+      Cluster names must not be longer than 20 characters and never
       start with a number.
 spec:
   validationFailureAction: Enforce
@@ -20,13 +20,13 @@ spec:
           kinds:
           - Cluster
     validate:
-      message: "cluster name must be no longer than 10 characters"
+      message: "cluster name must be no longer than 20 characters"
       deny:
         conditions:
           any:
           - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
             operator: GreaterThan
-            value: 10
+            value: 20
   - name: cluster-name-does-not-start-with-number
     match:
       any:
@@ -52,7 +52,7 @@ metadata:
     policies.kyverno.io/subject: MachinePools
     policies.kyverno.io/description: >-
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
-      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_POOL_NAME).
       In addition they must never start with a number.
 spec:
@@ -65,13 +65,13 @@ spec:
           kinds:
           - MachinePool
     validate:
-      message: "machine pool name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      message: "machine pool name must not be longer than 31 characters (20 for cluster name, 1 for '-', 10 for user defined named)"
       deny:
         conditions:
           any:
           - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
             operator: GreaterThan
-            value: 21
+            value: 31
 
 ---
 apiVersion: kyverno.io/v1
@@ -83,7 +83,7 @@ metadata:
     policies.kyverno.io/subject: MachineDeployments
     policies.kyverno.io/description: >-
       MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
-      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_DEPLOYMENT_NAME).
       In addition they must never start with a number.
 spec:
@@ -96,11 +96,11 @@ spec:
           kinds:
           - MachineDeployment
     validate:
-      message: "machine deployment name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      message: "machine deployment name must not be longer than 31 characters (20 for cluster name, 1 for '-', 10 for user defined named)"
       deny:
         conditions:
           any:
           - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
             operator: GreaterThan
-            value: 21
+            value: 31
 {{- end}}

--- a/policies/ux/cluster-names.yaml
+++ b/policies/ux/cluster-names.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/title: Restrict names of Clusters
     policies.kyverno.io/subject: Clusters
     policies.kyverno.io/description: >-
-      Cluster names must not be longer than 10 characters and never
+      Cluster names must not be longer than 20 characters and never
       start with a number.
 spec:
   validationFailureAction: Enforce
@@ -19,13 +19,13 @@ spec:
           kinds:
           - Cluster
     validate:
-      message: "cluster name must be no longer than 10 characters"
+      message: "cluster name must be no longer than 20 characters"
       deny:
         conditions:
           any:
           - key: "{{ length('{{request.object.metadata.name}}') }}"
             operator: GreaterThan
-            value: 10
+            value: 20
   - name: cluster-name-does-not-start-with-number
     match:
       any:
@@ -51,7 +51,7 @@ metadata:
     policies.kyverno.io/subject: MachinePools
     policies.kyverno.io/description: >-
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
-      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_POOL_NAME).
       In addition they must never start with a number.
 spec:
@@ -64,13 +64,13 @@ spec:
           kinds:
           - MachinePool
     validate:
-      message: "machine pool name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      message: "machine pool name must not be longer than 31 characters (20 for cluster name, 1 for '-', 10 for user defined named)"
       deny:
         conditions:
           any:
           - key: "{{ length('{{request.object.metadata.name}}') }}"
             operator: GreaterThan
-            value: 21
+            value: 31
 
 ---
 apiVersion: kyverno.io/v1
@@ -82,7 +82,7 @@ metadata:
     policies.kyverno.io/subject: MachineDeployments
     policies.kyverno.io/description: >-
       MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
-      therefore their total length must not exceed 21 (10 for CLUSTER_NAME
+      therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_DEPLOYMENT_NAME).
       In addition they must never start with a number.
 spec:
@@ -95,11 +95,11 @@ spec:
           kinds:
           - MachineDeployment
     validate:
-      message: "machine deployment name must not be longer than 21 characters (10 for cluster name, 1 for '-', 10 for user defined named)"
+      message: "machine deployment name must not be longer than 31 characters (20 for cluster name, 1 for '-', 10 for user defined named)"
       deny:
         conditions:
           any:
           - key: "{{ length('{{request.object.metadata.name}}') }}"
             operator: GreaterThan
-            value: 21
+            value: 31
 [[- end]]

--- a/tests/ats/manifests/invalid-clusters.yaml
+++ b/tests/ats/manifests/invalid-clusters.yaml
@@ -10,7 +10,7 @@ spec: {}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  # forbidden: longer than 10 characters
-  name: "a1234567890"
+  # forbidden: longer than 20 characters
+  name: "a12345678901234567890"
   namespace: default
 spec: {}

--- a/tests/ats/manifests/invalid-machinedeployments.yaml
+++ b/tests/ats/manifests/invalid-machinedeployments.yaml
@@ -1,8 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  # forbidden: longer than 21 characters
-  name: "0123456789-0123456789a"
+  # forbidden: longer than 31 characters
+  name: "0123456789-0123456789-0123456789a"
   namespace: default
 spec:
   clusterName: test

--- a/tests/ats/manifests/invalid-machinepools.yaml
+++ b/tests/ats/manifests/invalid-machinepools.yaml
@@ -1,8 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  # forbidden: longer than 21 characters
-  name: "0123456789-0123456789a"
+  # forbidden: longer than 31 characters
+  name: "0123456789-0123456789-0123456789a"
   namespace: default
 spec:
   clusterName: test


### PR DESCRIPTION
### Checklist
For task [#2958](https://github.com/giantswarm/roadmap/issues/2958)
- Increase the cluster name length to 20 characters
- Increase the machine pool name size to 31 characters
- Increase the machine deployment name size to 31 characters
- [x] Update changelog in CHANGELOG.md.
