### PR TITLE
Restrict `cluster-names` by GVK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `cluster-names` now targets Cluster by GVK
+
 ## [0.7.2] - 2024-01-29
 
 ### Changed

--- a/helm/kyverno-policies-ux/templates/cluster-names.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-names.yaml
@@ -18,7 +18,7 @@ spec:
       any:
       - resources:
           kinds:
-          - Cluster
+          - cluster.x-k8s.io/v1beta1/Cluster
     validate:
       message: "cluster name must be no longer than 20 characters"
       deny:
@@ -32,7 +32,7 @@ spec:
       any:
       - resources:
           kinds:
-          - Cluster
+          - cluster.x-k8s.io/v1beta1/Cluster
     validate:
       message: "cluster name must not start with a number"
       deny:


### PR DESCRIPTION
The cluster policy `cluster-names` currently targets any API called `Cluster`

This naming convention causes issues for crossplane resources which use a partially auto-generated name based on `claimRef.name` leading to names that exceed  the 20 character limit imposed by this policy

Instead, the policy should be instructed to ignore anything that is not in the GVK `cluster.x-k8s.io/v1beta1/Cluster`

### Checklist

- [x] Update changelog in CHANGELOG.md.
