### PR TITLE
Prepare for Kyverno v1.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `Enforce` instead of `enforce` as ValidationFailureAction.
+
 ### Added
 
 - Add `AzureCluster` to list of objects protected by the deletion prevention label

--- a/helm/kyverno-policies-ux/templates/clusters-label-service-priority.yaml
+++ b/helm/kyverno-policies-ux/templates/clusters-label-service-priority.yaml
@@ -11,7 +11,7 @@ metadata:
       that if set, it must have one of the well-defined values. For more details, see
       https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: restrict-label-value-changes

--- a/policies/ux/clusters-label-service-priority.yaml
+++ b/policies/ux/clusters-label-service-priority.yaml
@@ -10,7 +10,7 @@ metadata:
       that if set, it must have one of the well-defined values. For more details, see
       https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: restrict-label-value-changes


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32007

The usage of `enforce` has been depreacted. We should use `Enforce` instead.