### PR TITLE
Remove restriction for cluster names to start with a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cluster names can start with a number. Remove restriction that prevented that.
+
 ## [0.8.0] - 2025-02-19
 
 ### Changed

--- a/helm/kyverno-policies-ux/templates/cluster-names.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-names.yaml
@@ -8,8 +8,7 @@ metadata:
     policies.kyverno.io/title: Restrict names of Clusters
     policies.kyverno.io/subject: Clusters
     policies.kyverno.io/description: >-
-      Cluster names must not be longer than 20 characters and never
-      start with a number.
+      Cluster names must not be longer than 20 characters.
 spec:
   validationFailureAction: Enforce
   rules:
@@ -27,20 +26,6 @@ spec:
           - key: "{{ `{{` }} length('{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
             operator: GreaterThan
             value: 20
-  - name: cluster-name-does-not-start-with-number
-    match:
-      any:
-      - resources:
-          kinds:
-          - cluster.x-k8s.io/v1beta1/Cluster
-    validate:
-      message: "cluster name must not start with a number"
-      deny:
-        conditions:
-          any:
-          - key: "{{ `{{` }} regex_match('^[0-9].*', '{{ `{{` }}request.object.metadata.name{{ `}}` }}') {{ `}}` }}"
-            operator: Equals
-            value: true
 
 ---
 apiVersion: kyverno.io/v1
@@ -54,7 +39,6 @@ metadata:
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_POOL_NAME).
-      In addition they must never start with a number.
 spec:
   validationFailureAction: Enforce
   rules:
@@ -85,7 +69,6 @@ metadata:
       MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_DEPLOYMENT_NAME).
-      In addition they must never start with a number.
 spec:
   validationFailureAction: Enforce
   rules:

--- a/policies/ux/cluster-names.yaml
+++ b/policies/ux/cluster-names.yaml
@@ -7,8 +7,7 @@ metadata:
     policies.kyverno.io/title: Restrict names of Clusters
     policies.kyverno.io/subject: Clusters
     policies.kyverno.io/description: >-
-      Cluster names must not be longer than 20 characters and never
-      start with a number.
+      Cluster names must not be longer than 20 characters.
 spec:
   validationFailureAction: Enforce
   rules:
@@ -26,20 +25,6 @@ spec:
           - key: "{{ length('{{request.object.metadata.name}}') }}"
             operator: GreaterThan
             value: 20
-  - name: cluster-name-does-not-start-with-number
-    match:
-      any:
-      - resources:
-          kinds:
-          - cluster.x-k8s.io/v1beta1/Cluster
-    validate:
-      message: "cluster name must not start with a number"
-      deny:
-        conditions:
-          any:
-          - key: "{{ regex_match('^[0-9].*', '{{request.object.metadata.name}}') }}"
-            operator: Equals
-            value: true
 
 ---
 apiVersion: kyverno.io/v1
@@ -53,7 +38,6 @@ metadata:
       MachinePool names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_POOL_NAME).
-      In addition they must never start with a number.
 spec:
   validationFailureAction: Enforce
   rules:
@@ -84,7 +68,6 @@ metadata:
       MachineDeployment names are of the form {CLUSTER_NAME}-{MD_NAME},
       therefore their total length must not exceed 31 (20 for CLUSTER_NAME
       and 10 for MACHINE_DEPLOYMENT_NAME).
-      In addition they must never start with a number.
 spec:
   validationFailureAction: Enforce
   rules:

--- a/tests/ats/manifests/invalid-clusters.yaml
+++ b/tests/ats/manifests/invalid-clusters.yaml
@@ -2,14 +2,6 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  # forbidden: starts with a number
-  name: "0cluster"
-  namespace: default
-spec: {}
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
   # forbidden: longer than 20 characters
   name: "a12345678901234567890"
   namespace: default

--- a/tests/ats/manifests/valid-cluster.yaml
+++ b/tests/ats/manifests/valid-cluster.yaml
@@ -5,3 +5,10 @@ metadata:
   name: "cluster"
   namespace: default
 spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "0cluster"
+  namespace: default
+spec: {}

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -193,7 +193,6 @@ def test_invalid_cluster_name(fixtures, kube_cluster: Cluster) -> None:
     stderr = e.value.stderr
     assert "validate.kyverno.svc-fail" in stderr
     assert "cluster-name-maximum-length" in stderr
-    assert "cluster-name-does-not-start-with-number" in stderr
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
We have multiple customer clusters that start with a number and need to be migrated to CAPA.

We've ran some tests and doesn't seem to be any problems with cluster names starting with a number anymore.

### Checklist

- [x] Update changelog in CHANGELOG.md.
