### PR TITLE
Add clusterrole for admission-controller on cloud-director clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `clusterRole` for `admission-controller` on `cloud-director` clusters to support Kyverno `v0.19.0`.
+
 ## [0.10.0] - 2025-04-15
 
 ### Added

--- a/helm/kyverno-policies-ux/templates/cluster-role-admission-controller.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-role-admission-controller.yaml
@@ -1,11 +1,12 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyverno-policies-ux
+  name: kyverno-policies-ux-admission-controller
   labels:
     rbac.kyverno.io/aggregate-to-admission-controller: "true"
 rules:
-  - apiGroups: 
+  - apiGroups:
     - cluster.x-k8s.io
     - infrastructure.cluster.x-k8s.io
     - infrastructure.giantswarm.io

--- a/helm/kyverno-policies-ux/templates/cluster-role-background-controller.yaml
+++ b/helm/kyverno-policies-ux/templates/cluster-role-background-controller.yaml
@@ -1,0 +1,13 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if eq .Values.provider.kind "cloud-director" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-policies-ux-background-controller
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "list", "update", "delete"]
+{{- end }}

--- a/policies/ux/cluster-role-admission-controller.yaml
+++ b/policies/ux/cluster-role-admission-controller.yaml
@@ -1,12 +1,11 @@
-# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyverno-policies-ux
+  name: kyverno-policies-ux-admission-controller
   labels:
     rbac.kyverno.io/aggregate-to-admission-controller: "true"
 rules:
-  - apiGroups: 
+  - apiGroups:
     - cluster.x-k8s.io
     - infrastructure.cluster.x-k8s.io
     - infrastructure.giantswarm.io

--- a/policies/ux/cluster-role-background-controller.yaml
+++ b/policies/ux/cluster-role-background-controller.yaml
@@ -1,0 +1,12 @@
+[[- if eq .Values.provider.kind "cloud-director" ]]
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-policies-ux-background-controller
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "list", "update", "delete"]
+[[- end ]]


### PR DESCRIPTION
this is required for the [vcd credentials clusterpolicy](https://github.com/giantswarm/giantswarm-management-clusters/blob/main/management-clusters/gerbil/clusterpolicy-sync-vcd-credentials.yaml) to work correctly under Kyverno 0.19.0.

### Checklist

- [x] Update changelog in CHANGELOG.md.
